### PR TITLE
Fix touch axis swap and JSON NoMemory error in high-density airspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Then **log out and back in** (or reboot) for this to take effect.
 ### 3. Clone this repo
 
 ```bash
-git clone https://github.com/iamneilroberts/adsb-cyd.git
+git clone https://github.com/PFCPotato/adsb-cyd.git
 cd adsb-cyd
 ```
 

--- a/src/data/fetcher.cpp
+++ b/src/data/fetcher.cpp
@@ -283,6 +283,9 @@ static void fetch_task(void *param) {
                     }
                     _fstats.bytes_received += total;
 
+                    http.end();          // <-- moved up: free TLS session buffers before we parse
+                    http_mutex_release(); // <-- release the mutex too, since we're done with the network
+
                     // Parse with filter — only extract fields we need
                     JsonDocument filter;
                     JsonObject af = filter["ac"][0].to<JsonObject>();
@@ -331,8 +334,6 @@ static void fetch_task(void *param) {
                     _fstats.fetch_fail++;
                     error_log_add("HTTP %d", httpCode);
                 }
-                http.end();
-                http_mutex_release();
             }
         } else {
             error_log_add("Network down");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -266,8 +266,9 @@ static bool getTouchPoint(int &tx, int &ty) {
         sumX += touchRead16(0xD0);
         sumY += touchRead16(0x90);
     }
-    tx = map(sumX / 4, TOUCH_X_MIN, TOUCH_X_MAX, 0, 319);
-    ty = map(sumY / 4, TOUCH_Y_MIN, TOUCH_Y_MAX, 0, 239);
+    // Panel is physically rotated 90° vs display — X/Y channels swapped
+    tx = map(sumY / 4, TOUCH_Y_MAX, TOUCH_Y_MIN, 0, 319);  // was TOUCH_Y_MIN, TOUCH_Y_MAX
+    ty = map(sumX / 4, TOUCH_X_MIN, TOUCH_X_MAX, 0, 239);   // unchanged — this one's fine
     tx = constrain(tx, 0, 319);
     ty = constrain(ty, 0, 239);
     return true;
@@ -1482,6 +1483,7 @@ void loop() {
         }
     } else {
         if (touch_was_down && !long_press_fired) {
+            //Serial.printf("Touch release: tx=%d ty=%d (view=%d)\n", saved_tx, saved_ty, current_view);
             switch (current_view) {
                 case VIEW_RADAR:    handle_touch_radar(saved_tx); break;
                 case VIEW_ARRIVALS: handle_touch_arrivals(saved_tx, saved_ty); break;


### PR DESCRIPTION
Two fixes found while flashing this to a CYD board near Washington DC airspace:

1. Touch X/Y axes swapped and inverted on my unit. The resistive touch
   panel on this board revision appears to be mounted 90° rotated
   relative to the display, so raw X/Y readings needed to be swapped,
   and the resulting X axis needed its mapping direction reversed. This
   may be specific to a particular CYD hardware batch — worth flagging
   as something to check if touch zones don't respond as expected.

2. JSON error: NoMemory in high-aircraft-density areas. With
   ADSB_RADIUS_NM at the default 75nm near a busy metro area (three
   major airports in range), the raw HTTP response buffer, an open TLS
   session, and the ArduinoJson parse were all competing for heap
   simultaneously, since http.end() wasn't called until after parsing
   completed. Moving http.end() (and mutex release) to immediately
   after reading the response body, before deserialization, frees the
   TLS buffers before the parser needs the memory. Reducing
   ADSB_RADIUS_NM for dense areas helps further.

Tested on my board with both fixes; touch zones and JSON parsing are
now reliable.